### PR TITLE
Export setProjectAnnotations

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,5 @@
 import './globals';
 
 export * from './public-types';
+export { setProjectAnnotations } from './portable-stories';
 export { definePreview } from './preview';


### PR DESCRIPTION
It seems that `setProjectAnnotations` is not exported from `storybook-solidjs-vite`@10.0.0, which was exported in 9.0.3.

The function is necessary to setup `@storybook/addon-vitest` addon.
https://storybook.js.org/docs/writing-tests/integrations/vitest-addon#example-configuration-files