### PR TITLE
Allow storybook canary versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     },
     "peerDependencies": {
         "solid-js": "^1.9.0",
-        "storybook": "^10.0.0",
+        "storybook": "^0.0.0-0 || ^10.0.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "typescript": ">= 4.9.x"
     },


### PR DESCRIPTION
Hey there! At Storybook we do a lot of canary versions while developing features or experimenting with fixes. As I was testing our new Storybook init flow when using a canary version `0.0.0-pr-32921-sha-16b7aab0`, I noticed that the installation step fails because of dependency range restrictions.

This PR broadens dependency ranges to include Storybook canary versions (`0.0.0-` prefixed) and therefore make it easier for people to experience the framework with experimental versions of Storybook (we do this on all of our packages).

Thanks!