### PR TITLE
chore: remove repository directory from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/solidjs-community/storybook.git",
-        "directory": "packages/storybook-solid-vite"
+        "url": "git+https://github.com/solidjs-community/storybook.git"
     },
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION
This repository is no longer a monorepo, so the repository directory field is incorrect. The previous value also caused broken links on npmx.dev.

https://npmx.dev/package/storybook-solidjs-vite links to https://github.com/solidjs-community/storybook/tree/HEAD/packages/storybook-solid-vite
