### PR TITLE
fix(types): restore csf next type inference for shipped d.ts and AddMocks

### DIFF
--- a/src/renderer/shared/public-types.ts
+++ b/src/renderer/shared/public-types.ts
@@ -19,9 +19,11 @@ export const IS_SOLID_JSX_FLAG = '__isJSX';
 // This performs a downcast to function types that are mocks, when a mock fn is given to meta args.
 export type AddMocks<TArgs, DefaultArgs> = Simplify<{
     [T in keyof TArgs]: T extends keyof DefaultArgs
-        ? DefaultArgs[T] extends (...args: any) => any & { mock: object }
-            ? DefaultArgs[T]
-            : TArgs[T]
+        ? [DefaultArgs[T]] extends [never]
+            ? TArgs[T]
+            : DefaultArgs[T] extends (...args: any) => any & { mock: object }
+                ? DefaultArgs[T]
+                : TArgs[T]
         : TArgs[T];
 }>;
 

--- a/src/renderer/v1/public-types.ts
+++ b/src/renderer/v1/public-types.ts
@@ -1,6 +1,6 @@
 import { IS_SOLID_JSX_FLAG } from '../shared/public-types';
 
-import type { Component, ComponentProps } from 'solid-js-v1';
+import type { Component, ComponentProps } from 'solid-js';
 import type {
     AnnotatedStoryFn,
     Args,

--- a/src/renderer/v2/public-types.ts
+++ b/src/renderer/v2/public-types.ts
@@ -1,6 +1,6 @@
 import { IS_SOLID_JSX_FLAG } from '../shared/public-types';
 
-import type { Component, ComponentProps } from 'solid-js-v2';
+import type { Component, ComponentProps } from 'solid-js';
 import type {
     AnnotatedStoryFn,
     Args,


### PR DESCRIPTION
## What's broken

I ran into two TypeScript regressions in `10.1.0` that together make CSF Next unusable without workarounds. Both were working fine in `10.0.12`.

---

### 1. `solid-js-v1` leaks into the published `.d.ts`

The bundled `dist/public-types-*.d.ts` ships with:

```ts
import { Component, ComponentProps } from "solid-js-v1";
```

Since `solid-js-v1` is only a devDependency alias in this package, consumers can't resolve it. TypeScript silently falls back to `any`, which means `SolidComponent<TArgs>` loses all inference. Every story prop ends up as `unknown`. No hard error, just broken types.

In `10.0.12` the same files correctly imported from `'solid-js'`.

The fix here is straightforward: use `'solid-js'` directly in `renderer/v1/public-types.ts` and `renderer/v2/public-types.ts`. Both Solid 1.x and 2.x export compatible `Component<P>` and `ComponentProps<T>` from the bare specifier. I left the runtime alias in `entry-preview.ts` alone; only the type-only imports changed.

---

### 2. `AddMocks` collapses all args to `never` when meta has no `args`

The typed `meta.story()` overload relies on `AddMocks<T['args'], MetaInput['args']>`. When the meta omits `args`, which is the common pattern, `MetaInput['args']` becomes `Record<string, never>`, and things go sideways:

1. `keyof Record<string, never>` is `string`, so it matches every key in `TArgs`
2. `Record<string, never>[T]` is `never`
3. `never extends (...args: any) => any & { mock: object }` is `true` (never extends anything)
4. Every arg collapses to `never`, the typed overload becomes unmatchable

End result: a perfectly valid story copied straight from the docs throws `TS2769: No overload matches this call`.

The fix is a `[DefaultArgs[T]] extends [never]` early-exit before the mock detection — the standard TS idiom for checking if something is exactly `never` without triggering distributive behavior. The mock-downcast logic still works as before in all non-empty cases.

```diff
 export type AddMocks<TArgs, DefaultArgs> = Simplify<{
     [T in keyof TArgs]: T extends keyof DefaultArgs
-        ? DefaultArgs[T] extends (...args: any) => any & { mock: object }
-            ? DefaultArgs[T]
-            : TArgs[T]
+        ? [DefaultArgs[T]] extends [never]
+            ? TArgs[T]
+            : DefaultArgs[T] extends (...args: any) => any & { mock: object }
+                ? DefaultArgs[T]
+                : TArgs[T]
         : TArgs[T];
 }>;
```

---

## One more thing

Between `10.0.12` and `10.1.0`, `render?:` in `meta.story()` overload 1 also became `render:` (required). With the `AddMocks` fix, overload 2 handles the no-`render` case correctly so it's not user-visible anymore. I didn't touch it here, but happy to open a separate issue if it's worth discussing whether that was intentional.
